### PR TITLE
Fixes README image paths + allows artifact and release hashes to match

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,15 @@ jobs:
       - name: Make application
         run: |
           make
-      - name: Publish build to GH Actions
-        uses: actions/upload-artifact@v4
-        with:
-          path: out
-          name: GBARunner3
       - name: Package for release
         run: |
           cd out && zip -r ../GBARunner3.zip *
+      - name: Publish build to GH Actions
+        uses: actions/upload-artifact@v7
+        with:
+          path: GBARunner3.zip
+          name: GBARunner3
+          archive: false
       - name: Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GBARunner3
 
 <div align="center">
-    <img src="docs/images/GBARunner3_Logo.png" width="1000"/>
+    <img src="docs/Images/GBARunner3_Logo.png" width="1000"/>
 </div>    
 
 ![Build](https://img.shields.io/badge/build-passing-brightgreen)
@@ -218,13 +218,13 @@ If no per-game config is found, GBARunner3 will fall back to the global `GBARunn
 ## True GBA Color Correction    
 
 <div align="center">
-    <img src="docs/images/GBARunner3_GBA_Models.jpg" width="300"/>
+    <img src="docs/Images/GBARunner3_GBA_Models.jpg" width="300"/>
 </div>    
 
 The original GBA (AGB-001) uses a non-backlit, reflective LCD display. It not only requires external light to be visible, but also features an unconventional RGB subpixel layout:      
 
 <div align="center">
-    <img src="docs/images/GBARunner3_GBA_Pixels.jpg" width="250"/>
+    <img src="docs/Images/GBARunner3_GBA_Pixels.jpg" width="250"/>
 </div>    
 
 As a result, many early GBA games were designed with oversaturated and overly bright palettes, often deviating from true color accuracy to remain visible. These look normal on the AGB-001, but on later models like the GBA SP (AGS-101) and Nintendo DS Lite (USG-001), which use standard backlit RGB panels, these appear washed out or color shifted.
@@ -232,7 +232,7 @@ As a result, many early GBA games were designed with oversaturated and overly br
 Interestingly, models like the DS Phat (NTR-001) and the Game Boy Micro (OXY-001), which, despite having backlit screens, still use reflective LCDs with a pixel arrangement closer to that of the AGB-001, preserving the original look more accurately.      
 
 <div align="center">
-    <img src="docs/images/GBARunner3_ColorCorrection_1.webp" width="400"/>
+    <img src="docs/Images/GBARunner3_ColorCorrection_1.webp" width="400"/>
 </div>    
 
 Emulators commonly apply shaders to simulate the AGB-001’s look on modern displays, recreating how games were originally meant to be seen on a real GBA display. But since the Nintendo DS lacks shader support, GBARunner3 takes a different approach: **it intercepts palette writes at runtime and uses a precomputed LUT to apply color correction.**
@@ -240,13 +240,13 @@ Emulators commonly apply shaders to simulate the AGB-001’s look on modern disp
 The LUT is generated at boot based on selected color profile matrices, derived from libretro shaders by **hunterk and Pokefan531**. Below are direct feed screenshots from GBARunner3, showcasing the available color correction profiles.  
 
 <p align="center">
-    <img src="docs/images/GBARunner3_ColorLut_1.webp" width="450">
-    <img src="docs/images/GBARunner3_ColorLut_2.webp" width="450">
+    <img src="docs/Images/GBARunner3_ColorLut_1.webp" width="450">
+    <img src="docs/Images/GBARunner3_ColorLut_2.webp" width="450">
 </p>    
 
 <p align="center">
-    <img src="docs/images/GBARunner3_ColorLut_3.webp" width="450">
-    <img src="docs/images/GBARunner3_ColorLut_4.webp" width="450">
+    <img src="docs/Images/GBARunner3_ColorLut_3.webp" width="450">
+    <img src="docs/Images/GBARunner3_ColorLut_4.webp" width="450">
 </p>    
 
 #### Gamma Correction Levels    
@@ -254,7 +254,7 @@ The LUT is generated at boot based on selected color profile matrices, derived f
 Gamma correction further improves visuals by deepening contrast and color intensity. This is especially useful for games with washed-out palettes. The image below shows each available gamma level in GBARunner3:  
 
 <div align="center">
-    <img src="docs/images/GBARunner3_GammaLut_1.webp" width="900"/>
+    <img src="docs/Images/GBARunner3_GammaLut_1.webp" width="900"/>
 </div>   
 
 ## Troubleshooting


### PR DESCRIPTION
The first commit fixes the capitalization in the README image paths so that it can display the correct images from 'Images' rather than the nonexistent images from 'images'.

The second commit modifies the release workflow to use the same ZIP and compression level for both the release file and the release workflow artifact. This makes it easy to prove that the release build actually came from the code in the repository by comparing SHA256 hashes, so this increases trust.