### PR TITLE
Fix RTC BCD decoding

### DIFF
--- a/code/core/arm9/source/Peripherals/RomGpio/RomGpioRtc.cpp
+++ b/code/core/arm9/source/Peripherals/RomGpio/RomGpioRtc.cpp
@@ -492,15 +492,15 @@ u32 RomGpioRtc::ToSecondsSinceJanuary2000(const rio_rtc_datetime_t& dateTime, bo
         days += GetNumberOfDaysInMonth(2000 + yearsSince2000, i);
     }
 
-    u32 hours = FromBcd(dateTime.time.hour & 0x1F);
+    u32 hours = FromBcd(dateTime.time.hour & 0x3F);
     if (!time24h && (dateTime.time.hour & 0x80))
     {
         hours += 12;
     }
 
     return ((days * 24u + hours) * 60u
-        + FromBcd(dateTime.time.minute & 0x3F)) * 60u
-        + FromBcd(dateTime.time.second & 0x3F);
+        + FromBcd(dateTime.time.minute & 0x7F)) * 60u
+        + FromBcd(dateTime.time.second & 0x7F);
 }
 
 void RomGpioRtc::FromSecondsSinceJanuary2000(u32 secondsSinceJanuary2000, rio_rtc_datetime_t& dateTime, bool time24h) const


### PR DESCRIPTION
The emulated GBA cartridge RTC is built from a sampled RTC snapshot, but the conversion path masked out valid BCD bits before decoding the values.

- Hour was decoded with `0x1F` instead of `0x3F`.
- Minute was decoded with `0x3F` instead of `0x7F`.
- Second was decoded with `0x3F` instead of `0x7F`.

This produced two user-visible bugs in RTC games.

- Minutes `40-59` were decoded as `00-19`, so the emulated clock jumped backward by 40 minutes whenever real time crossed `:40`.
- Hours `20-23` were decoded as `00-03`, so evening time wrapped around after `20:00`.

The result was a clock that appeared to advance, but drifted further behind real time and could jump sharply backward at specific boundaries.

This PR fixes RTC BCD decoding in `RomGpioRtc::ToSecondsSinceJanuary2000()` so hour, minute, and second keep their full documented bit ranges and prevent RTC-based games from gradually lagging behind real time, jumping backward at `:40`, and wrapping `20:00-23:59` to `00:00-03:59`.

References:
- GBATEK, GBA Cart Real-Time Clock (RTC): https://mgba-emu.github.io/gbatek/#gba-cart-real-time-clock-rtc
- GBATEK, DS Real-Time Clock (RTC): https://mgba-emu.github.io/gbatek/#ds-real-time-clock-rtc
